### PR TITLE
Add dcl metadata override and cover page metadata support

### DIFF
--- a/_extensions/texnative/partials/page-cover.tex
+++ b/_extensions/texnative/partials/page-cover.tex
@@ -29,6 +29,14 @@ $if(client)$
 {\bf Client:} & $client.name$ \\
 $endif$
 
+$if(clientname)$
+{\bf Client:} & $clientname$ \\
+$endif$
+
+$if(reportperiod)$
+{\bf Report Period:} & $reportperiod$ \\
+$endif$
+
 $if(contact_person)$
   {\bf Contact Person:} & $contact_person$ \\
 $endif$

--- a/_extensions/texnative/texnative_dcl.lua
+++ b/_extensions/texnative/texnative_dcl.lua
@@ -112,6 +112,12 @@ function Meta(meta)
     return meta
   end
 
+  -- Support simple 'dcl' property to override level
+  -- This allows: -M dcl="confidential" instead of -M data_classification_label.level="confidential"
+  if meta.dcl ~= nil then
+    dcl.level = meta.dcl
+  end
+
   -- Validate configuration
   local valid, err = M.validate_config(dcl)
   if not valid then

--- a/_extensions/texnative/texnative_dcl.lua
+++ b/_extensions/texnative/texnative_dcl.lua
@@ -112,10 +112,10 @@ function Meta(meta)
     return meta
   end
 
-  -- Support simple 'dcl' property to override level
-  -- This allows: -M dcl="confidential" instead of -M data_classification_label.level="confidential"
-  if meta.dcl ~= nil then
-    dcl.level = meta.dcl
+  -- Support simple 'data_classification_level' property to override level
+  -- This allows: -M data_classification_level="confidential" instead of -M data_classification_label.level="confidential"
+  if meta.data_classification_level ~= nil then
+    dcl.level = meta.data_classification_level
   end
 
   -- Validate configuration


### PR DESCRIPTION
- texnative_dcl.lua: Add support for simple 'dcl' property to override data classification level from command line (-M dcl="confidential") instead of the verbose -M data_classification_label.level syntax
- page-cover.tex: Add support for clientname and reportperiod metadata fields for flexible report generation

Both changes are backward compatible and add new functionality.